### PR TITLE
Refactor to_marc data into hash, use hash for Endnote citation

### DIFF
--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -173,6 +173,7 @@ module Blacklight::Solr::Document::MarcExport
       
       if marc_obj[first_value[0].to_s]
         marc_obj.find_all{|f| (first_value[0].to_s) === f.tag}.each do |field|
+          # byebug if (field.tag == "260" || field.tag == "264")
           if field[first_value[1]].to_s or field[second_value[1]].to_s
             text << "#{key.gsub('_','')}"
             if field[first_value[1]].to_s
@@ -563,5 +564,24 @@ module Blacklight::Solr::Document::MarcExport
     temp_name = name.split(", ")
     return temp_name.last + " " + temp_name.first
   end 
+
+  def to_object
+    doc = {}
+    doc['author'] = to_marc['100']['a']
+    doc['pub_place'] = to_marc['260']['a'] || to_marc['264']['a']
+    doc['pub_date'] = to_marc['260']['c'] || to_marc['264']['c']
+    doc['publisher'] = to_marc['260']['b'] || to_marc['264']['b']
+    doc['series'] = "#{to_marc['440']['a']} #{to_marc['490']['a']}"
+    doc['isbn'] = to_marc['20']['a']
+    doc['issn'] = to_marc['22']['a']
+    doc['title'] = "#{to_marc['245']['a']} #{to_marc['245']['b']}"
+    doc['url'] = to_marc['856']['u']
+    doc['edition'] = to_marc['250']['a']
+    doc['add_entry'] = to_marc['700']['a']
+    doc['num_pages'] = to_marc['300']['a']
+    doc['cite_as'] = to_marc['524']['a']
+    doc['scale'] = to_marc['255']['a']
+    doc
+  end
   
 end

--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -561,7 +561,7 @@ module Blacklight::Solr::Document::MarcExport
     # is missing and if not, we'll set it to second value of condition
     # Some fields are either/or, some are both (if present)
 
-    doc['isbn']       =   to_marc['020'] && to_marc['020']['a']
+    doc['isbn']       =   record_to_text('020')
     doc['issn']       =   to_marc['022'] && to_marc['022']['a']
     doc['author']     =   to_marc['100'] && to_marc['100']['a']
     doc['edition']    =   to_marc['250'] && to_marc['250']['a']
@@ -605,6 +605,15 @@ module Blacklight::Solr::Document::MarcExport
     end
 
     doc
+  end
+
+  def record_to_text(marc_field)
+    marc_text = ""
+    to_marc.find_all{|f| marc_field === f.tag}.each do |entry|
+      marc_text << entry.value
+      marc_text << "\n"
+    end
+    marc_text
   end
   
 end


### PR DESCRIPTION
Added a `to_object` function which maps all of the known `to_marc` data into reasonably-named fields which can be re-used elsewhere. Can't use `to_hash` because the Ruby Marc class already uses it in a rather ugly way which I was not able to use very effectively. 

Testing steps:

Point current Gemfile to this repo:

```ruby
gem 'blacklight-marc', github: 'yalelibrary/blacklight-marc', branch: 'add_fields'
```

Then use some records to test various Endnote exports. Just replace `search.library.yale.edu` with `localhost:3000`. You may need to point to prod (or prod-like server) in order to find all of these records. @ksprague25 will have more information about this.

http://search.library.yale.edu/catalog/13781969
http://search.library.yale.edu/catalog/6483822
http://search.library.yale.edu/catalog/13781969
http://search.library.yale.edu/catalog/4937811
http://search.library.yale.edu/catalog/8165298

For each record, you'd want to verify it looks good opening it in Endnote as well as verify if the plain text looks okay.

You can also view the Trello card for more information about fields/test records: https://trello.com/c/RdB1DUOa

Known bug(s):

1. For record 13781969, current production gives both ISBN numbers correctly. In refactor, for some reason I'm only getting one, as I only see one in the MARC 020 field. So the production gem seems to be finding the other record... somewhere. I don't know where.
2. The %J field doesn't seem to be mapping in Endnote. This *should* be the Series Info, and if you look at the plain text of the .endnote format, it looks fine, but it's getting added into the field above (%I, which is publisher name) -- my guess is b/c it doesn't recognize the %J format for some reason. This could be suppressed by simply removing the %J format in the Endnote algorithm around line 160.

