### PR TITLE
Refactor citations and add Endnote fields

### DIFF
--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -150,6 +150,7 @@ module Blacklight::Solr::Document::MarcExport
       "%@" => "isbn",
       "%_@" => "issn",
       "%T" => "title",
+      "%P" => "num_pages",
       "%U" => "url",
       "%7" => "edition"
     }

--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -158,7 +158,8 @@ module Blacklight::Solr::Document::MarcExport
     # convert marc data to object hash
     marc_object = to_object
     
-    text = ''
+    # This is a legacy of the old export_as_endnote left for compatibility
+    text = "%0 Generic\n"
 
     # For each value in our end_note_format hash, iterate through
     # all marc_object fields and put them into string

--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -173,6 +173,7 @@ module Blacklight::Solr::Document::MarcExport
       
       if marc_obj[first_value[0].to_s]
         marc_obj.find_all{|f| (first_value[0].to_s) === f.tag}.each do |field|
+          # byebug if (field.tag == "260" || field.tag == "264")
           if field[first_value[1]].to_s or field[second_value[1]].to_s
             text << "#{key.gsub('_','')}"
             if field[first_value[1]].to_s
@@ -563,5 +564,24 @@ module Blacklight::Solr::Document::MarcExport
     temp_name = name.split(", ")
     return temp_name.last + " " + temp_name.first
   end 
+
+  def to_object
+    doc = {}
+    doc['author'] = to_marc['100']['a']
+    doc['pub_place'] = to_marc['260']['a'] || to_marc['264']['a']
+    doc['pub_date'] = to_marc['260']['c'] || to_marc['264']['c']
+    doc['publisher'] = to_marc['260']['b'] || to_marc['264']['b']
+    doc['series'] = "#{to_marc['440']['a']} #{to_marc['490']['a']}"
+    doc['isbn'] = to_marc['20']['a']
+    doc['issn'] = to_marc['22']['a']
+    doc['title'] = "#{to_marc['245']['a']} #{to_marc['245']['b']}"
+    doc['url'] = to_marc['856']['u']
+    doc['edition'] = to_marc['250']['a']
+    doc['add_entry'] = to_marc['700']['a']
+    doc['num_pages'] = to_marc['300']['a']
+    doc['cite_as'] = to_marc['524']['a']
+    doc['scale'] = to_marc['255']['a']
+    doc
+  end
   
 end

--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -561,7 +561,7 @@ module Blacklight::Solr::Document::MarcExport
     # is missing and if not, we'll set it to second value of condition
     # Some fields are either/or, some are both (if present)
 
-    doc['isbn']       =   to_marc['020'] && to_marc['020']['a']
+    doc['isbn']       =   record_to_text('020')
     doc['issn']       =   to_marc['022'] && to_marc['022']['a']
     doc['author']     =   to_marc['100'] && to_marc['100']['a']
     doc['edition']    =   to_marc['250'] && to_marc['250']['a']
@@ -605,6 +605,15 @@ module Blacklight::Solr::Document::MarcExport
     end
 
     doc
+  end
+
+  def record_to_text(marc_field)
+    marc_text = ""
+    to_marc.find_all{|f| marc_field === f.tag}.each do |entry|
+      marc_text << entry.value
+      marc_text << "\n"
+    end
+    marc_text
   end
   
 end

--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -146,13 +146,15 @@ module Blacklight::Solr::Document::MarcExport
       "%D" => "pub_date",
       "%E" => "add_entry",
       "%I" => "publisher",
-      "%J" => "series",
       "%@" => "isbn",
       "%_@" => "issn",
+      "%S" => "series",
       "%T" => "title",
       "%P" => "num_pages",
       "%U" => "url",
-      "%7" => "edition"
+      "%7" => "edition",
+      # nowhere to put scale, so use notes in %Z
+      "%Z" => "scale",
     }
     
     # convert marc data to object hash

--- a/spec/lib/marc_export_spec.rb
+++ b/spec/lib/marc_export_spec.rb
@@ -694,15 +694,15 @@ describe Blacklight::Solr::Document::MarcExport do
         endnote_entries[$1] << $2
       end
 
-      expect(endnote_entries["0"]).to eq(Set.new(["Generic"])) # I have no idea WHY this is correct, it is definitely not legal, but taking from earlier test for render_endnote in applicationhelper, the previous version of this.  jrochkind.
-      expect(endnote_entries["D"]).to eq(Set.new(["p2001. "]))
-      expect(endnote_entries["C"]).to eq(Set.new(["[United States] : "]))
-      expect(endnote_entries["E"]).to eq(Set.new(["Greer, Lowell. ", "Lubin, Steven. ", "Chase, Stephanie, ", "Brahms, Johannes, ", "Beethoven, Ludwig van, ", "Krufft, Nikolaus von, "]))
-      expect(endnote_entries["I"]).to eq(Set.new(["Harmonia Mundi USA, "]))
-      expect(endnote_entries["T"]).to eq(Set.new(["Music for horn "]))
+      #expect(endnote_entries["0"]).to eq(Set.new(["Generic"])) # I have no idea WHY this is correct, it is definitely not legal, but taking from earlier test for render_endnote in applicationhelper, the previous version of this.  jrochkind.
+      expect(endnote_entries["D"]).to eq(Set.new(["p2001."]))
+      expect(endnote_entries["C"]).to eq(Set.new(["[United States] :"]))
+      expect(endnote_entries["E"]).to eq(Set.new(["Greer, Lowell.", "Lubin, Steven.", "Chase, Stephanie,", "Brahms, Johannes,", "Beethoven, Ludwig van,", "Krufft, Nikolaus von,"]))
+      expect(endnote_entries["I"]).to eq(Set.new(["Harmonia Mundi USA,"]))
+      expect(endnote_entries["T"]).to eq(Set.new(["Music for horn"]))
 
       #nothing extra
-      expect(Set.new(endnote_entries.keys)).to eq(Set.new(["0", "C", "D", "E", "I", "T"]))      
+      expect(Set.new(endnote_entries.keys)).to eq(Set.new(["C", "D", "E", "I", "T"]))
     end
   end
 

--- a/spec/lib/marc_export_spec.rb
+++ b/spec/lib/marc_export_spec.rb
@@ -694,7 +694,7 @@ describe Blacklight::Solr::Document::MarcExport do
         endnote_entries[$1] << $2
       end
 
-      #expect(endnote_entries["0"]).to eq(Set.new(["Generic"])) # I have no idea WHY this is correct, it is definitely not legal, but taking from earlier test for render_endnote in applicationhelper, the previous version of this.  jrochkind.
+      expect(endnote_entries["0"]).to eq(Set.new(["Generic"])) # I have no idea WHY this is correct, it is definitely not legal, but taking from earlier test for render_endnote in applicationhelper, the previous version of this.  jrochkind.
       expect(endnote_entries["D"]).to eq(Set.new(["p2001."]))
       expect(endnote_entries["C"]).to eq(Set.new(["[United States] :"]))
       expect(endnote_entries["E"]).to eq(Set.new(["Greer, Lowell.", "Lubin, Steven.", "Chase, Stephanie,", "Brahms, Johannes,", "Beethoven, Ludwig van,", "Krufft, Nikolaus von,"]))
@@ -702,7 +702,7 @@ describe Blacklight::Solr::Document::MarcExport do
       expect(endnote_entries["T"]).to eq(Set.new(["Music for horn"]))
 
       #nothing extra
-      expect(Set.new(endnote_entries.keys)).to eq(Set.new(["C", "D", "E", "I", "T"]))
+      expect(Set.new(endnote_entries.keys)).to eq(Set.new(["0", "C", "D", "E", "I", "T"]))
     end
   end
 


### PR DESCRIPTION
In order to add additional Endnote fields, it was important to refactor the way citations are created. Now, a couple of functions have been added in order to format the MARC objects in a reasonable way which can then be used in multiple formats (Refworks, Endnote, etc.). May also be used to enable RIS in the future.

These functions are:

`to_object`: Creates a Hash object with various fields like `doc['isbn']` and `doc['author']` which can be used to easily grab necessary data for various citation formats without having to worry about specific MARC implemtnation
`record_to_array`: Takes a specific MARC field (i.e., '020.a') and turns it into an array of 0 or more strings with the MARC data requested. Could return a 0 length array, or however many objects it finds, depending on the MARC field. Called by `to_object`.

Now, the `export_as_endnote()` function will use the Hash created by `to_object` to refer to various citation fields (i.e. mapping %A to `doc['author']`). 

Test Steps:

1. Point `search-frontend` to the Pull Request Git Branch and run a `bundle install`.
2. Download Endnote citations from the following resources and verify additional fields look correct:
- http://localhost:3000/catalog/13781969
- http://localhost:3000/catalog/6483822
- http://localhost:3000/catalog/8165298
3. Verify everything looks good in Endnote.
4. Run tests from quick-search frontend:
- Login to Vagrant box
- CD into your Quicksearch folder
- Run command: `rspec ../blacklight-marc/spec/lib/marc_export.rb` and verify all tests complete
(This may involve you having to clone the gem into the Vagrant box if you haven't already)

Once this is done, we can do the following to put these changes into Quicksearch Production:

1. Merge `add_fields` into `test`
2. Test Quicksearch with `test` branch of this Gem
3. Merge into `prod`
4. Change Quicksearch to have `blacklight-marc` gem point to this Repo in `prod`
5. Do PR on this change with additional testing

After that, we can look into supporting additional formats.