### PR TITLE
Added RIS format type to marc_export

### DIFF
--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -16,6 +16,7 @@ module Blacklight::Solr::Document::MarcExport
     document.will_export_as(:openurl_ctx_kev, "application/x-openurl-ctx-kev")
     document.will_export_as(:refworks_marc_txt, "text/plain")
     document.will_export_as(:endnote, "application/x-endnote-refer")
+    document.will_export_as(:ris, "application/ris")
   end
 
 
@@ -158,7 +159,7 @@ module Blacklight::Solr::Document::MarcExport
     }
     
     # convert marc data to object hash
-    marc_object = to_object
+    doc_object = to_object
     
     # This is a legacy of the old export_as_endnote left for compatibility
     text = "%0 Generic\n"
@@ -167,11 +168,50 @@ module Blacklight::Solr::Document::MarcExport
     # all marc_object fields and put them into string
     # Each marc_object could have 0 or more strings in array
     
-    end_note_format.each do |endnote_key,marc_key|
-      marc_object[marc_key].each do |marc_value|
-        text << "#{endnote_key} #{marc_value}\n"
+    end_note_format.each do |endnote_key,doc_key|
+      doc_object[doc_key].each do |doc_value|
+        text << "#{endnote_key} #{doc_value}\n"
       end
     end
+    text
+  end
+
+  def to_ris_text
+    ris_format = {
+      "AU" => "author",
+      "CY" => "pub_place",
+      "PY" => "pub_date",
+      "TA" => "add_entry",
+      "PB" => "publisher",
+      # could be either, not sure if will cause problems
+      "SN" => "isbn",
+      "SN" => "issn",
+      "M1" => "series",
+      "T1" => "title",
+      "EP" => "num_pages",
+      "UR" => "url",
+      "ET" => "edition",
+      # nowhere to put scale, so use notes in %Z
+      "N1" => "scale",
+    }
+    
+    # convert marc data to object hash
+    doc_object = to_object
+    
+    # Not sure how to find content type, just use generic
+    text = "TY  - GEN\n"
+
+    # For each value in our ris_format hash, iterate through
+    # all doc_object fields and put them into string
+    # Each doc_object could have 0 or more strings in array
+    
+    ris_format.each do |ris_key,obj_key|
+      doc_object[obj_key].each do |obj_value|
+        text << "#{ris_key}  - #{obj_value}\n"
+      end
+    end
+    # have to end RIS
+    text << "ER  -\n"
     text
   end
 


### PR DESCRIPTION
Added ability to export using `to_ris_text` to match the same from the Summon-Citation_Export gem. That way, when we're dealing with mixed results, we can still give an RIS-enabled export format shared across Solr/Summon.

Test steps:

1. Point your search-frontend blacklight-marc gem to the right place:
gem 'blacklight-marc', :git => 'git@github.com:yalelibrary/blacklight-marc.git', branch: '5_add_ris'
2. Go to Books+ in search-frontend
3. Put a byebug in the CatalogController in the `show` method around line 195
4. When you hit that point, make sure you can do `@document.to_ris_text`
5. Remove the byebug
6. Verify you can still Export to Endnote inside Books+ (aka we didn't break anything)
7. Verify you can still Export to Refworks inside Books+
