### PR TITLE
14 - Use HTTPS to send data to refworks rather than HTTP

### DIFF
--- a/app/helpers/blacklight_marc_helper.rb
+++ b/app/helpers/blacklight_marc_helper.rb
@@ -2,7 +2,7 @@ module BlacklightMarcHelper
 
   # This method should move to BlacklightMarc in Blacklight 6.x
   def refworks_export_url params = {}
-    "http://www.refworks.com/express/expressimport.asp?vendor=#{CGI.escape(params[:vendor] || application_name)}&filter=#{CGI.escape(params[:filter] || "MARC Format")}&encoding=65001" + (("&url=#{CGI.escape(params[:url])}" if params[:url]) || "")
+    "https://www.refworks.com/express/expressimport.asp?vendor=#{CGI.escape(params[:vendor] || application_name)}&filter=#{CGI.escape(params[:filter] || "MARC Format")}&encoding=65001" + (("&url=#{CGI.escape(params[:url])}" if params[:url]) || "")
   end
 
   def refworks_solr_document_path opts = {}

--- a/spec/helpers/blacklight_marc_helper_spec.rb
+++ b/spec/helpers/blacklight_marc_helper_spec.rb
@@ -43,4 +43,22 @@ describe BlacklightMarcHelper do
     end
   end
 
+  describe "#refworks_export_url" do
+    it "should use https" do
+      expect(helper.refworks_export_url(:vendor=>"test", :filter => 'filter_test', :url => 'http://library.yale.edu')).to \
+        match /^https:\/\//
+    end
+    it "should return correct url" do
+      expect(helper.refworks_export_url(:vendor=>"test", :filter => 'filter_test', :url => 'http://library.yale.edu')).to \
+        eq 'https://www.refworks.com/express/expressimport.asp?vendor=test&filter=filter_test&encoding=65001&url=http%3A%2F%2Flibrary.yale.edu'
+      expect(helper.refworks_export_url(:vendor=>"test vendor space", :filter => 'filter_test;filter2', :url => 'https://library.yale.edu')).to \
+        eq 'https://www.refworks.com/express/expressimport.asp?vendor=test+vendor+space&filter=filter_test%3Bfilter2&encoding=65001&url=https%3A%2F%2Flibrary.yale.edu'
+    end
+    it 'should use application_name when no vendor is provided' do
+      allow(helper).to receive_messages(application_name: 'AppName')
+      expect(helper.refworks_export_url(:filter => 'filter_test;filter2', :url => 'https://library.yale.edu')).to \
+        eq 'https://www.refworks.com/express/expressimport.asp?vendor=AppName&filter=filter_test%3Bfilter2&encoding=65001&url=https%3A%2F%2Flibrary.yale.edu'
+    end
+  end
+
 end


### PR DESCRIPTION
Closes #14 

Changes BlacklightMarcHelper::refworks_export_url to return URL with https rather than http.
Adds test for BlacklightMarcHelper::refworks_export_url.

## Testing

### Testing The Blacklight Marc Gem
Ensure that your build and test environment are setup correctly by checking out test and running: 
```
bundle exec rspec ./spec/helpers/blacklight_marc_helper_spec.rb
```

3 examples should pass, 0 failures

After you verify that you are able to test:
```
git fetch
git checkout 14_change_refworks_url_to_use_https
bundle exec rspec ./spec/helpers/blacklight_marc_helper_spec.rb
```

6 examples should pass, 0 failures

### Testing Integration with Search Frontend
These steps should be done from your search-frontend development environment.
The test for this change in the gem is in the 894_update_refworks_form_to_use_https branch.
Check out that branch; test should initially fail. Then update the gem to this branch and a the test should pass:
```
git fetch
git checkout 894_update_refworks_form_to_use_https
RUBYOPT="-W0" bundle exec rspec ./spec/features/citation_export_spec.rb
```
You should see 8 examples, 2 failures.
Update the Gemfile for the project for testing purposes:
Add the branch to the line with BlacklightMark:
```
gem 'blacklight-marc', :git => 'git@github.com:yalelibrary/blacklight-marc.git', :branch => '14_change_refworks_url_to_use_https'
```
Update the gem:
```
bundle update blacklight-marc
```
Rerun the test:
```
RUBYOPT="-W0" bundle exec rspec ./spec/features/citation_export_spec.rb
```

You should see 8 examples, 0 failures.

