### PR TITLE
18 fix helper function typo

### DIFF
--- a/app/views/catalog/show.refworks.erb
+++ b/app/views/catalog/show.refworks.erb
@@ -1,1 +1,1 @@
-<%= render_refworks_texts(@document) %>
+<%= render_refworks_texts([@document]) %>

--- a/app/views/catalog/show.refworks.erb
+++ b/app/views/catalog/show.refworks.erb
@@ -1,1 +1,1 @@
-<%= render_refworks_text(@document) %>
+<%= render_refworks_texts(@document) %>


### PR DESCRIPTION
Closes #18 

### This fixes an error that's visible from search-frontend.

Start search-frontend in vagrant.  To see the error, open an item view in Books+.  Add .refworks to the end of the URL to request in .refworks format. (This is different than choosing from the Export As menu.)
e.g. ```http://localhost:3000/catalog/12826302.refworks```

### Update the Gemfile for search-frontend to test this PR:
Open the Gemfile for search-frontend and edit the entry for blacklight-marc:
```gem 'blacklight-marc', :git => 'git@github.com:yalelibrary/blacklight-marc.git', :branch => '18_fix_helper_function_typo```

Run ```bundle install``` for search-frontend.

### Test again with updated gem
Restart search frontend and try the broken URL again.  You should see metadata in a text, in a MARC-like format.  (You may need to view document source to see the line breaks properly.)

### Comment
I'm not sure where people are linking to the .refworks URLs from.  The menu option to export as Refworks doesn't seem to use the document format request to get the export, so I'm not sure where the requests are coming from. I may be missing some link to these types of URLs, or maybe these are old URLs that some person or system has bookmarked.