### PR TITLE
Removed initial key that gets overwritten on the next line

### DIFF
--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -184,7 +184,6 @@ module Blacklight::Solr::Document::MarcExport
       "TA" => "add_entry",
       "PB" => "publisher",
       # could be either, not sure if will cause problems
-      "SN" => "isbn",
       "SN" => "issn",
       "M1" => "series",
       "T1" => "title",


### PR DESCRIPTION
Closes #12 

## Setup
1. cd into search-frontend
1. `git checkout rspec_capy_test` (so random tests do not fail)
1. Edit the Gemfile and point the blacklight-marc gem by adding `, branch: 'dup_key_fix'`
1. bundle install
1. Connect to VPN

## Testing
1. Run the rspec suite: `xvfb-run -a bundle exec rspec`
1. Ensure there are no failures except for maybe the morris test.
1. Ensure that you do not get a warning for `Duplicate SN key on line 187`.

## Clean up
1. `git checkout Gemfile*`
1. `bundle install`