### PR TITLE
add 264 for publish date/info

### DIFF
--- a/app/models/concerns/blacklight/marc/document_export.rb
+++ b/app/models/concerns/blacklight/marc/document_export.rb
@@ -477,9 +477,18 @@ end
     end
     text
   end
+
   def setup_pub_date(record)
-    if !record.find{|f| f.tag == '260'}.nil?
-      pub_date = record.find{|f| f.tag == '260'}
+    text = pub_date_26x(record,"264").present? ? pub_date_26x(record,"264") : (pub_date_26x(record,"260").present? ? pub_date_26x(record,"260") : "")
+  end
+
+  def setup_pub_info(record)
+    text = pub_info_26x(record,"264").present? ? pub_info_26x(record,"264") : (pub_info_26x(record,"260").present? ? pub_info_26x(record,"260") : "")
+  end
+
+  def pub_date_26x(record, field_26x)
+    if !record.find{|f| f.tag == field_26x }.nil?
+      pub_date = record.find{|f| f.tag == field_26x}
       if pub_date.find{|s| s.code == 'c'}
         date_value = pub_date.find{|s| s.code == 'c'}.value.gsub(/[^0-9|n\.d\.]/, "")[0,4] unless pub_date.find{|s| s.code == 'c'}.value.gsub(/[^0-9|n\.d\.]/, "")[0,4].blank?
       end
@@ -487,9 +496,10 @@ end
     end
     clean_end_punctuation(date_value) if date_value
   end
-  def setup_pub_info(record)
+
+  def pub_info_26x(record, field_26x)
     text = ''
-    pub_info_field = record.find{|f| f.tag == '260'}
+    pub_info_field = record.find{|f| f.tag == field_26x}
     if !pub_info_field.nil?
       a_pub_info = pub_info_field.find{|s| s.code == 'a'}
       b_pub_info = pub_info_field.find{|s| s.code == 'b'}
@@ -503,6 +513,7 @@ end
     end
     return nil if text.strip.blank?
     clean_end_punctuation(text.strip)
+
   end
 
   def mla_citation_title(text)


### PR DESCRIPTION
To fix #2704
https://app.zenhub.com/workspaces/quicksearch-5e6f993ede3cd5175f6d41f2/issues/yalelibrary/search-frontend/2704

No change in the search-frontend:

- To test:

-- git pull blacklight-marc PR https://github.com/yalelibrary/blacklight-marc/pull/38

-- Then go to search-frontend directory to test:
-- pull this PR to local blacklight-marc
-- Go to search-frontend directory
-- add the blacklight-marc gem to vagrant local by add this to the Vagrantfile:
--config.vm.synced_folder "/directory of your local path where blacklight-marc saved/blacklight-marc", "/home/vagrant/blacklight-marc"
-- update gemfile to point the blacklight-marc to local vagrant directory: gem 'blacklight-marc', path: '/home/vagrant/blacklight-marc'
-- bundle install
-- vagrant up
-- vagrant ssh search-frondend
-- rails s -p 3000

- Test records:

1. publish date/info in: 264 fields 
   http://localhost:3000/catalog/15880975
   expect to see: date and publish information in the APA/MLA citation
![Screen Shot 2022-11-15 at 3 50 05 PM](https://user-images.githubusercontent.com/46331329/202022608-a0556c98-e07f-4660-9447-3416293659bb.png)

2. publish date/info in: 260 fields 
       http://localhost:3000/catalog/7419487
      expect to see: date and publish information in the APA/MLA citation
   
![Screen Shot 2022-11-15 at 3 51 25 PM](https://user-images.githubusercontent.com/46331329/202022878-f2a360e8-8423-42eb-aa2c-3fa0ee8ccdd4.png)
