### PR TITLE
period, date, sound record, series title

### DIFF
--- a/app/models/concerns/blacklight/marc/document_export.rb
+++ b/app/models/concerns/blacklight/marc/document_export.rb
@@ -638,11 +638,11 @@ module Blacklight::Marc::DocumentExport
             b_title_info = title_info_field.find {|s| s.code == 'b'}
             a_title_info = clean_end_punctuation(a_title_info.value.strip) unless a_title_info.nil?
             b_title_info = clean_end_punctuation(b_title_info.value.strip) unless b_title_info.nil?
-            text += a_title_info unless a_title_info.nil?
+            text += a_title_info.strip unless a_title_info.nil?
             if !a_title_info.nil? and !b_title_info.nil?
                 text += ": "
             end
-            text += b_title_info unless b_title_info.nil?
+            text += b_title_info.strip unless b_title_info.nil?
         end
         series_title_field = record.find {|f| f.tag == '490'}
         if !series_title_field.nil?


### PR DESCRIPTION
close #47 
1. period after author
2. fix date xxxx-
3. replace publisher information with physical description of sound records 
4. add series title 
To test:
 - pull this PR in the local repo of blacklight-marc
 - switch to the search-frontend directory
     -- in the docker-comopose.yml: 
       add `- the path of the blacklight-marc in your local:/app/blacklight-marc`
     -- in the Gemfile
     add `gem 'blacklight-marc', path: '/app/blacklight-marc'
- run `docker compose run search-frontend bundle install`
- run `docker-compose restart search-frontend`
- run `docker compose up`
-  go to localhost:3000
- Example: 
period after author:
http://localhost:3000/catalog/3084270
http://localhost:3000/catalog/201837
http://localhost:3000/catalog/2644136
http://localhost:3000/catalog/2969166
http://localhost:3000/catalog/11200229
http://localhost:3000/catalog/4354860 

date: decision? http://localhost:3000/catalog/11437005 1900-1950 (still use this based on Suzanne's suggest)  or 1900-50
http://localhost:3000/catalog/11200229 strip out publish information, add 300 $a if is sound recording

Others not fix, it may be a catalog data issue:
http://localhost:3000/catalog/4354860 (edited by)  author information is gotten form 100/700, Edited by is only in 245 $c in this record, the type of relator of relationship  such s editor, translator, compiler  are in the $e $4 of 700 . The record does not have $4 $e in 700 field (it is more like a catalog data issue) 
same as https://localhost:3000/catalog/4009139 translator 
